### PR TITLE
Support Arrays

### DIFF
--- a/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_ComplexCustomer_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_ComplexCustomer_Tests.cs
@@ -1,4 +1,3 @@
-
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using Foundation.ObjectHydrator.Generators;
@@ -57,6 +56,30 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
             foreach (Address address in customer.Addresses)
             {
                 Trace.WriteLine(address.AddressLine1);
+            }
+        }
+
+
+        [Test]
+        public void CanLoadSingleComplexCustomerWithPhoneList()
+        {
+            var listSize = 6;
+            var args = new object[] {listSize};
+
+            var customer = new Hydrator<ComplexCustomer>()
+                .With(x => x.PhoneNumbers, new ArrayGenerator<string>(listSize, new AmericanPhoneGenerator()))
+                .GetSingle();
+
+
+            Assert.IsNotNull(customer);
+            Assert.IsTrue(customer.PhoneNumbers.Length == listSize,
+                  string.Format("customer.PhoneNumbers.Length [{0}] is not expected value of [{1}].",
+                  customer.PhoneNumbers.Length, listSize));
+
+            Trace.WriteLine("Addresses Generated...");
+            foreach (string ph in customer.PhoneNumbers)
+            {
+                Trace.WriteLine(ph);
             }
         }
 

--- a/Foundation.ObjectHydrator.Tests/POCOs/ComplexCustomer.cs
+++ b/Foundation.ObjectHydrator.Tests/POCOs/ComplexCustomer.cs
@@ -36,6 +36,8 @@ namespace Foundation.ObjectHydrator.Tests.POCOs
         
 
         public string HomePhone { get; set; }
+        public string WorkPhone { get; set; }
+        public string[] PhoneNumbers { get; set; }
 
         public CustomerType Type { get; set; }
 

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Generators\AmericanPhoneGenerator.cs" />
     <Compile Include="Generators\AmericanPostalCodeGenerator.cs" />
     <Compile Include="Generators\AmericanStateGenerator.cs" />
+    <Compile Include="Generators\ArrayGenerator.cs" />
     <Compile Include="Generators\BooleanGenerator.cs" />
     <Compile Include="Generators\ByteArrayGenerator.cs" />
     <Compile Include="Generators\CCVGenerator.cs" />

--- a/Foundation.ObjectHydrator/Generators/ArrayGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/ArrayGenerator.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using Foundation.ObjectHydrator.Interfaces;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class ArrayGenerator<T> : ListGenerator<T>
+	{
+		public ArrayGenerator(int length, IGenerator<T> elementGenerator = null) : base(length, elementGenerator)
+		{
+		}
+		
+		public override IList<T> Generate()
+		{
+			return base.Generate().ToArray();
+		}
+	}
+}

--- a/Foundation.ObjectHydrator/Generators/Generator.cs
+++ b/Foundation.ObjectHydrator/Generators/Generator.cs
@@ -19,6 +19,11 @@ namespace Foundation.ObjectHydrator.Generators
 
         public object Generate()
         {
+            if (_info.PropertyType.IsArray)
+            {
+                return Array.CreateInstance(_info.PropertyType.GetElementType(), 0);
+            }
+
             return Activator.CreateInstance(_info.PropertyType);
         }
 

--- a/Foundation.ObjectHydrator/Generators/ListGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/ListGenerator.cs
@@ -1,28 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Foundation.ObjectHydrator.Interfaces;
 
 namespace Foundation.ObjectHydrator.Generators
 {
-    public class ListGenerator<T>:IGenerator<IList<T>>
+	public class ListGenerator<T>:IGenerator<IList<T>>
     {
         private readonly int listLength;
+        private readonly IGenerator<T> elementGenerator;
 
-        public ListGenerator(int length)
+        public ListGenerator(int length, IGenerator<T> elementGenerator = null)
         {
+            this.elementGenerator =  elementGenerator ?? new TypeGenerator<T>();
             listLength = length;
         }
 
         #region IGenerator<IList<T>> Members
 
-        public IList<T> Generate()
+        public virtual IList<T> Generate()
         {
             IList<T> list = new List<T>();
             for (int i = 0; i < listLength; i++)
             {
-                list.Add(new TypeGenerator<T>().Generate());
+                list.Add(elementGenerator.Generate());
             }
             return list;
         }


### PR DESCRIPTION
The existing implemenation throws an exception when trying to populate a complex class with a property with an Array.  I modified the generator so it will create empty arrays instead, after which you can manually assign an Array generator to the property (inherits from List Generator).

I also included a change where you can supply a generator to the list generator so it can make collections of strings, instead of just collections of complex types (due to string not having a default constructor).