### PR TITLE
Enabled 0% With Plus Four percentage for postal code.

### DIFF
--- a/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
@@ -155,6 +155,15 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         }
 
         [Test]
+        public void AmericanPostalCodeGeneratorNoPlusFourTest()
+        {
+            IGenerator<string> postalgen = new AmericanPostalCodeGenerator(0);
+            var zipcode = (string)postalgen.Generate();
+            Assert.IsNotNull(zipcode);
+            Assert.IsTrue(IsAmericanPostalCodeValid(zipcode));
+        }
+
+        [Test]
         public void TextGeneratorTest()
         {
             IGenerator<string> textgen = new TextGenerator();

--- a/Foundation.ObjectHydrator/Generators/AmericanPostalCodeGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/AmericanPostalCodeGenerator.cs
@@ -22,7 +22,7 @@ namespace Foundation.ObjectHydrator.Generators
         {
             string plusFour = String.Empty;
 
-            if (random.Next(0, 100) % (100 / PercentageWithPlusFour) == 0)
+            if (PercentageWithPlusFour > 0 && random.Next(0, 100) % (100 / PercentageWithPlusFour) == 0)
             {
                 plusFour = String.Format("-{0:0000}", random.Next(1, 9999));
             }


### PR DESCRIPTION
Passing in 0 to the AmericanPostalCodeGenerator causes a divide by 0
error when generating the postal code. This fix allows 0 to be passed in
if the user does not want any plus fours with their generated postal codes.