### PR TITLE
Generic EnumGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+.vs/
 # Roslyn cache directories
 *.ide/
 

--- a/Foundation.ObjectHydrator.Tests/Foundation.ObjectHydrator.Tests.csproj
+++ b/Foundation.ObjectHydrator.Tests/Foundation.ObjectHydrator.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Foundation.ObjectHydrator.Tests</RootNamespace>
     <AssemblyName>Foundation.ObjectHydrator.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -40,6 +40,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,6 +51,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -59,6 +61,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.core">

--- a/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_ComplexCustomer_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_ComplexCustomer_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Foundation.ObjectHydrator.Generators;
 using Foundation.ObjectHydrator.Tests.POCOs;
@@ -112,6 +113,17 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
                 .GetSingle();
 
             Assert.AreEqual(lastNameDefault, hy.LastName);
+        }
+
+
+        [Test]
+        public void CanLoadSingleComplexCustomerWithEnum()
+        {
+            var hydrator = new Hydrator<ComplexCustomer>()
+                .WithEnum(x => x.Type, Enum.GetValues(typeof(CustomerType)));
+            var customer = hydrator.GetSingle();
+            Assert.IsNotNull(customer);
+            Assert.IsTrue(customer.Type > 0, "CustomerType is expected");
         }
     }
 }

--- a/Foundation.ObjectHydrator.Tests/POCOs/ComplexCustomer.cs
+++ b/Foundation.ObjectHydrator.Tests/POCOs/ComplexCustomer.cs
@@ -7,10 +7,10 @@ namespace Foundation.ObjectHydrator.Tests.POCOs
 {
     public enum CustomerType
     {
-        Lead,
-        Prospect,
-        Active,
-        Inactive
+        Lead = 1,
+        Prospect = 2,
+        Active = 3,
+        Inactive = 4
     }
 
     public class ComplexCustomer

--- a/Foundation.ObjectHydrator/DefaultTypeMap.cs
+++ b/Foundation.ObjectHydrator/DefaultTypeMap.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Foundation.ObjectHydrator.Interfaces;
 using Foundation.ObjectHydrator.Generators;
 
@@ -13,11 +11,26 @@ namespace Foundation.ObjectHydrator
         {
             Add(new Map<DateTime>().Using(new DateTimeGenerator()));
             Add(new Map<double>().Using(new DoubleGenerator()));
+            Add(new Map<double?>().Using(new NullableDoubleGenerator()));
             Add(new Map<Double>().Using(new DoubleGenerator()));
+            Add(new Map<Double?>().Using(new NullableDoubleGenerator()));
+
+            Add(new Map<decimal>().Using(new DecimalGenerator()));
+            Add(new Map<decimal?>().Using(new NullableDecimalGenerator()));
+            Add(new Map<Decimal>().Using(new DecimalGenerator()));
+            Add(new Map<Decimal?>().Using(new NullableDecimalGenerator()));
+
             Add(new Map<int>().Using(new IntegerGenerator()));
+            Add(new Map<int?>().Using(new NullableIntegerGenerator()));
             Add(new Map<Int32>().Using(new IntegerGenerator()));
+            Add(new Map<Int32?>().Using(new NullableIntegerGenerator()));
+
             Add(new Map<bool>().Using(new BooleanGenerator()));
+            Add(new Map<bool?>().Using(new NullableBooleanGenerator()));
+
             Add(new Map<Guid>().Using(new GuidGenerator()));
+            Add(new Map<Guid?>().Using(new NullableGuidGenerator()));
+
             Add(new Map<byte[]>().Using(new ByteArrayGenerator(8)));
             Add(new EnumMap());
             Add(new Map<string>()

--- a/Foundation.ObjectHydrator/EnumMap.cs
+++ b/Foundation.ObjectHydrator/EnumMap.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Foundation.ObjectHydrator.Interfaces;
 using System.Reflection;
 using Foundation.ObjectHydrator.Generators;
@@ -25,7 +22,7 @@ namespace Foundation.ObjectHydrator
 
         IMapping IMap.Mapping(PropertyInfo info)
         {
-            return new Mapping<object>(info, new EnumGenerator(Enum.GetValues(info.PropertyType)));
+            return new Mapping<object>(info, new EnumGenerator<object>(Enum.GetValues(info.PropertyType)));
         }
 
         #endregion

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Foundation.ObjectHydrator</RootNamespace>
     <AssemblyName>Foundation.ObjectHydrator</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -50,6 +50,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -59,6 +60,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
@@ -91,9 +91,16 @@
     <Compile Include="Generators\ByteArrayGenerator.cs" />
     <Compile Include="Generators\CCVGenerator.cs" />
     <Compile Include="Generators\CompanyNameGenerator.cs" />
+    <Compile Include="Generators\DecimalGenerator.cs" />
     <Compile Include="Generators\FromListGetListGenerator.cs" />
     <Compile Include="Generators\FromListGetSingleGenerator.cs" />
     <Compile Include="Generators\Generator.cs" />
+    <Compile Include="Generators\IntegerGenerator1.cs" />
+    <Compile Include="Generators\NullableBooleanGenerator.cs" />
+    <Compile Include="Generators\NullableDecimalGenerator.cs" />
+    <Compile Include="Generators\NullableDoubleGenerator.cs" />
+    <Compile Include="Generators\NullableGuidGenerator.cs" />
+    <Compile Include="Generators\NullableIntegerGenerator.cs" />
     <Compile Include="Generators\PasswordGenerator.cs" />
     <Compile Include="Generators\TrackingNumberGenerator.cs" />
     <Compile Include="Generators\CountryCodeGenerator.cs" />

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <package >
-	<metadata>
-		<id>objecthydrator</id>
-		<version>$version$</version>
-		<title>objecthydrator</title>
-		<authors>Andrian</authors>
-		<owners>Andrian</owners>
-		<projectUrl>https://github.com/deathgore/ObjectHydrator</projectUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<description>ObjectHydrator</description>
-		<releaseNotes>Generic EnumGenerator</releaseNotes>
-		<copyright>Copyright 2016</copyright>
-		<tags>objecthydrator</tags>
-	</metadata>
-	<files>
-			<file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib\net45\" />
-			<file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib\net45\" />
-		</files>
+        <metadata>
+                <id>objecthydrator</id>
+                <version>$version$</version>
+                <title>objecthydrator</title>
+                <authors>Andrian</authors>
+                <owners>Andrian</owners>
+                <projectUrl>https://github.com/deathgore/ObjectHydrator</projectUrl>
+                <requireLicenseAcceptance>false</requireLicenseAcceptance>
+                <description>ObjectHydrator</description>
+                <releaseNotes>Generic EnumGenerator</releaseNotes>
+                <copyright>Copyright 2016</copyright>
+                <tags>objecthydrator</tags>
+        </metadata>
+        <files>
+                        <file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib\net461\" />
+                        <file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib\net461\" />
+                </files>
 </package>

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
@@ -14,7 +14,7 @@
                 <tags>objecthydrator</tags>
         </metadata>
         <files>
-                        <file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib\net461\" />
-                        <file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib\net461\" />
+                        <file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib/net461" />
+                        <file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib/net461" />
                 </files>
 </package>

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
@@ -1,16 +1,20 @@
 <?xml version="1.0"?>
 <package >
-  <metadata>
-    <id>objecthydrator</id>
-    <version>$version$</version>
-    <title>objecthydrator</title>
-    <authors>Andrian</authors>
-    <owners>Andrian</owners>
-    <projectUrl>https://github.com/deathgore/ObjectHydrator</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>ObjectHydrator</description>
-    <releaseNotes>Generic EnumGenerator</releaseNotes>
-    <copyright>Copyright 2016</copyright>
-    <tags>objecthydrator</tags>
-  </metadata>
+	<metadata>
+		<id>objecthydrator</id>
+		<version>$version$</version>
+		<title>objecthydrator</title>
+		<authors>Andrian</authors>
+		<owners>Andrian</owners>
+		<projectUrl>https://github.com/deathgore/ObjectHydrator</projectUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>ObjectHydrator</description>
+		<releaseNotes>Generic EnumGenerator</releaseNotes>
+		<copyright>Copyright 2016</copyright>
+		<tags>objecthydrator</tags>
+		<files>
+			<file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib\.NetFramework 4.0\" />
+			<file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib\.NetFramework 4.0\" />
+		</files>
+	</metadata>
 </package>

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
@@ -12,9 +12,9 @@
 		<releaseNotes>Generic EnumGenerator</releaseNotes>
 		<copyright>Copyright 2016</copyright>
 		<tags>objecthydrator</tags>
-		<files>
+	</metadata>
+	<files>
 			<file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib\.NetFramework 4.0\" />
 			<file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib\.NetFramework 4.0\" />
 		</files>
-	</metadata>
 </package>

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>objecthydrator</id>
+    <version>$version$</version>
+    <title>objecthydrator</title>
+    <authors>Andrian</authors>
+    <owners>Andrian</owners>
+    <projectUrl>https://github.com/deathgore/ObjectHydrator</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>ObjectHydrator</description>
+    <releaseNotes>Generic EnumGenerator</releaseNotes>
+    <copyright>Copyright 2016</copyright>
+    <tags>objecthydrator</tags>
+  </metadata>
+</package>

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.nuspec
@@ -14,7 +14,7 @@
 		<tags>objecthydrator</tags>
 	</metadata>
 	<files>
-			<file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib\.NetFramework 4.0\" />
-			<file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib\.NetFramework 4.0\" />
+			<file src="bin\Release\Foundation.ObjectHydrator.dll" target="lib\net45\" />
+			<file src="bin\Release\Foundation.ObjectHydrator.pdb" target="lib\net45\" />
 		</files>
 </package>

--- a/Foundation.ObjectHydrator/Generators/DecimalGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/DecimalGenerator.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Foundation.ObjectHydrator.Interfaces;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class DecimalGenerator : IGenerator<decimal>
+    {
+        Random random;
+
+        public decimal MinimumValue { get; set; }
+        public decimal MaximumValue { get; set; }
+        public int DecimalPlaces { get; set; }
+
+        public DecimalGenerator()
+            : this(0, 100)
+        { }
+
+        public DecimalGenerator(int decimalPlaces):this(0,100,decimalPlaces)
+        {
+
+        }
+
+        public DecimalGenerator(decimal minimumValue, decimal maximumValue)
+            : this(minimumValue, maximumValue, 2)
+        { }
+
+        public DecimalGenerator(decimal minimumValue, decimal maximumValue, int decimalPlaces)
+        {
+            if (minimumValue > maximumValue)
+            {
+                throw new ArgumentOutOfRangeException("minimumValue", minimumValue, "minimumValue must be <= maximumValue");
+            }
+
+            if (decimalPlaces > 5)
+            {
+                throw new ArgumentOutOfRangeException("decimalPlaces", decimalPlaces, "decimalPlaces must be <=5;");
+            }
+
+            MinimumValue = minimumValue;
+            MaximumValue = maximumValue;
+            DecimalPlaces = decimalPlaces;
+
+            random = RandomSingleton.Instance.Random;
+        }
+
+        public decimal Generate()
+        {
+            decimal toReturn;
+            double decimalPart;
+
+            // The offset adjustment to get down to an Int minimum value
+            decimal offset = MinimumValue - Math.Floor(MinimumValue);
+            decimal adjustedMinimum = MinimumValue - offset;
+            decimal adjustedMaximum = MaximumValue - offset;
+
+            toReturn = random.Next((int)adjustedMinimum, (int)adjustedMaximum);
+            decimalPart = random.NextDouble();
+            decimalPart *= Math.Pow(10, DecimalPlaces);
+            decimalPart = (int)decimalPart;
+
+            toReturn += Convert.ToDecimal(decimalPart / Math.Pow(10, DecimalPlaces));
+
+            // Now, add back the offset
+            toReturn += offset;
+
+            return toReturn;
+        }
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/EnumGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/EnumGenerator.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Foundation.ObjectHydrator.Interfaces;
 
 namespace Foundation.ObjectHydrator.Generators
 {
-    public class EnumGenerator:IGenerator<object>
+    public class EnumGenerator<T> : IGenerator<T>
     {
         Random random;
         Array EnumValues;
@@ -18,9 +15,9 @@ namespace Foundation.ObjectHydrator.Generators
 
         }
 
-        public object Generate()
+        public T Generate()
         {
-            return EnumValues.GetValue(random.Next(0, EnumValues.Length - 1));
+            return (T)EnumValues.GetValue(random.Next(0, EnumValues.Length - 1));
         }
     }
 }

--- a/Foundation.ObjectHydrator/Generators/IntegerGenerator1.cs
+++ b/Foundation.ObjectHydrator/Generators/IntegerGenerator1.cs
@@ -1,0 +1,6 @@
+﻿namespace Foundation.ObjectHydrator.Generators
+{
+    public class IntegerGenerator<T>
+    {
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableBooleanGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableBooleanGenerator.cs
@@ -1,0 +1,17 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableBooleanGenerator : IGenerator<bool?>
+    {
+        private readonly BooleanGenerator _innerGenerator;
+
+        public NullableBooleanGenerator()
+        {
+            _innerGenerator = new BooleanGenerator();
+        }
+
+        public bool? Generate()
+            => _innerGenerator.Generate();
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableDecimalGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableDecimalGenerator.cs
@@ -1,0 +1,29 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableDecimalGenerator : IGenerator<decimal?>
+    {
+        private readonly DecimalGenerator _innerGenerator;
+
+        public NullableDecimalGenerator()
+            : this(0, 100)
+        { }
+
+        public NullableDecimalGenerator(int decimalPlaces)
+            : this(0,100,decimalPlaces)
+        { }
+
+        public NullableDecimalGenerator(decimal minimumValue, decimal maximumValue)
+            : this(minimumValue, maximumValue, 2)
+        { }
+
+        public NullableDecimalGenerator(decimal minimumValue, decimal maximumValue, int decimalPlaces)
+        {
+            _innerGenerator = new DecimalGenerator(minimumValue, maximumValue, decimalPlaces);
+        }
+
+        public decimal? Generate()
+            => _innerGenerator.Generate();
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableDoubleGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableDoubleGenerator.cs
@@ -1,0 +1,31 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableDoubleGenerator : IGenerator<double?>
+    {
+        private readonly DoubleGenerator _innerGenerator;
+        public NullableDoubleGenerator()
+            : this(0.0, 100)
+        { }
+
+        public NullableDoubleGenerator(int decimalPlaces)
+            :this(0.0,100.00,decimalPlaces)
+        {
+
+        }
+
+        public NullableDoubleGenerator(double minimumValue, double maximumValue)
+            : this(minimumValue, maximumValue, 2)
+        { }
+
+
+        public NullableDoubleGenerator(double minimumValue, double maximumValue, int decimalPlaces)
+        {
+            _innerGenerator = new DoubleGenerator(minimumValue, maximumValue, decimalPlaces);
+        }
+
+        public double? Generate()
+            => _innerGenerator.Generate();
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableGuidGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableGuidGenerator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Foundation.ObjectHydrator.Interfaces;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableGuidGenerator : IGenerator<Guid?>
+    {
+        private readonly GuidGenerator _innerGenerator;
+
+        public NullableGuidGenerator()
+        {
+            _innerGenerator = new GuidGenerator();
+        }
+
+        public Guid? Generate()
+            => _innerGenerator.Generate();
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableIntegerGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableIntegerGenerator.cs
@@ -1,0 +1,20 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableIntegerGenerator : IGenerator<int?>
+    {
+        private readonly IntegerGenerator _innIntegerGenerator;
+        public NullableIntegerGenerator()
+            : this(0, 100)
+        { }
+
+        public NullableIntegerGenerator(int minimumValue, int maximumValue)
+        {
+            _innIntegerGenerator = new IntegerGenerator(minimumValue, maximumValue);
+        }
+
+        public int? Generate()
+            => _innIntegerGenerator.Generate();
+    }
+}

--- a/Foundation.ObjectHydrator/Hydrator.cs
+++ b/Foundation.ObjectHydrator/Hydrator.cs
@@ -212,7 +212,7 @@ namespace Foundation.ObjectHydrator
         /// <returns>This instance of the Hydrator for type T.</returns>
         public Hydrator<T> WithEnum<TProperty>(Expression<Func<T, TProperty>> expression, Array enumValues)
         {
-            IGenerator<TProperty> gen = (IGenerator<TProperty>)new EnumGenerator(enumValues);
+            IGenerator<TProperty> gen = new EnumGenerator<TProperty>(enumValues);
             SetPropertyMap(expression, gen);
             return this;
 

--- a/SampleWebApplication/SampleWebApplication.csproj
+++ b/SampleWebApplication/SampleWebApplication.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SampleWebApplication</RootNamespace>
     <AssemblyName>SampleWebApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <SccProjectName>
     </SccProjectName>
     <SccLocalPath>
@@ -27,6 +27,11 @@
     <UpgradeBackupLocation />
     <UseIISExpress>false</UseIISExpress>
     <TargetFrameworkProfile />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,6 +42,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -46,6 +52,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SampleWebApplication/Web.config
+++ b/SampleWebApplication/Web.config
@@ -2,6 +2,14 @@
 <configuration>
   <appSettings/>
   <connectionStrings/>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.6.1" />
+      </system.Web>
+  -->
   <system.web>
     <!-- 
             Set compilation debug="true" to insert debugging 
@@ -9,7 +17,7 @@
             affects performance, set this value to true only 
             during development.
         -->
-    <compilation debug="false" targetFramework="4.0"/>
+    <compilation debug="false" targetFramework="4.6.1"/>
     <!--
             The <authentication> section enables configuration 
             of the security authentication mode used by 


### PR DESCRIPTION
Hydrator.WithEnum generates a **System.InvalidCastException**

System.InvalidCastException :
  Unable to cast object of type 'Foundation.ObjectHydrator.Generators.EnumGenerator' to type 'Foundation.ObjectHydrator.Interfaces.IGenerator`1[Foundation.ObjectHydrator.Tests.POCOs.CustomerType]'.
   at Foundation.ObjectHydrator.Hydrator`1.WithEnum[TProperty](Expression`1 expression, Array enumValues) in D:\git_external\ObjectHydrator\Foundation.ObjectHydrator\Hydrator.cs:line 215
   at Foundation.ObjectHydrator.Tests.HydratorTests.Hydrator_ComplexCustomer_Tests.CanLoadSingleComplexCustomerWithEnum() in D:\git_external\ObjectHydrator\Foundation.ObjectHydrator.Tests\HydratorTests\Hydrator_ComplexCustomer_Tests.cs:line 122