### PR TITLE
Added support for Nullable Types

### DIFF
--- a/Foundation.ObjectHydrator.Tests/Foundation.ObjectHydrator.Tests.csproj
+++ b/Foundation.ObjectHydrator.Tests/Foundation.ObjectHydrator.Tests.csproj
@@ -86,11 +86,14 @@
     <Compile Include="GeneratorTests\Generator_Tests.cs" />
     <Compile Include="HydratorTests\Hydrator_InjectedGenerator_Test.cs" />
     <Compile Include="HydratorTests\Hydrator_ComplexCustomer_Tests.cs" />
+    <Compile Include="HydratorTests\Hydrator_PetShop_Tests.cs" />
     <Compile Include="HydratorTests\Hydrator_SimpleAddress_Tests.cs" />
     <Compile Include="HydratorTests\Hydrator_SimpleCustomer_Tests.cs" />
     <Compile Include="HydratorTests\InjectedGenerator.cs" />
     <Compile Include="POCOs\Address.cs" />
+    <Compile Include="POCOs\Animal.cs" />
     <Compile Include="POCOs\ComplexCustomer.cs" />
+    <Compile Include="POCOs\PetShop.cs" />
     <Compile Include="POCOs\RestrictedDescriptionCustomer.cs" />
     <Compile Include="POCOs\SimpleCustomer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using Foundation.ObjectHydrator.Generators;
 using Foundation.ObjectHydrator.Interfaces;
+using Foundation.ObjectHydrator.Tests.POCOs;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -77,7 +78,10 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         [Test]
         public void EnumGeneratorTest()
         {
-            //IGenerator enumgen = new EnumGenerator();
+            var enumgenerator = new EnumGenerator(Enum.GetValues(typeof(CustomerType)));
+            var enumvalue = enumgenerator.Generate();
+            Assert.IsNotNull(enumvalue);
+            Assert.IsInstanceOf<CustomerType>(enumvalue);
         }
 
         [Test]
@@ -413,7 +417,15 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             var intvalue = intgenerator.Generate();
             Assert.IsNotNull(intvalue);
             Assert.IsInstanceOf<int?>(intvalue);
+        }
 
+        [Test]
+        public void NullableEnumGenerator()
+        {
+            var enumgenerator = new NullableEnumGenerator(Enum.GetValues(typeof(CustomerType)), false);
+            var enumvalue = enumgenerator.Generate();
+            Assert.IsNotNull(enumvalue);
+            Assert.IsInstanceOf<CustomerType?>(enumvalue);
         }
     }
 }

--- a/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using Foundation.ObjectHydrator.Generators;
+﻿using Foundation.ObjectHydrator.Generators;
 using Foundation.ObjectHydrator.Interfaces;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Foundation.ObjectHydrator.Tests.GeneratorTests
 {
@@ -14,7 +14,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void FirstNameGeneratorTest()
         {
             IGenerator<string> fng = new FirstNameGenerator();
-            var firstname = (string) fng.Generate();
+            var firstname = (string)fng.Generate();
             Assert.IsNotNull(firstname);
         }
 
@@ -22,7 +22,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void LastNameGeneratorTest()
         {
             IGenerator<string> lng = new LastNameGenerator();
-            var lastname = (string) lng.Generate();
+            var lastname = (string)lng.Generate();
             Assert.IsNotNull(lastname);
         }
 
@@ -30,7 +30,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void CompanyNameGeneratorTest()
         {
             IGenerator<string> cng = new CompanyNameGenerator();
-            var companyname = (string) cng.Generate();
+            var companyname = (string)cng.Generate();
             Assert.IsNotNull(companyname);
         }
 
@@ -38,7 +38,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void DateTimeGeneratorWithDefaultTest()
         {
             IGenerator<DateTime> dtg = new DateTimeGenerator();
-            var checkme = (DateTime) dtg.Generate();
+            var checkme = (DateTime)dtg.Generate();
             var current = DateTime.Now;
             Assert.IsNotNull(checkme);
             Assert.That(checkme, Is.InRange(current.AddYears(-10), current.AddYears(10)));
@@ -51,7 +51,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             var mymax = Convert.ToDateTime("1/1/1980");
 
             IGenerator<DateTime> dtg = new DateTimeGenerator(mymin, mymax);
-            var checkme = (DateTime) dtg.Generate();
+            var checkme = (DateTime)dtg.Generate();
             Assert.That(checkme, Is.InRange(mymin, mymax));
         }
 
@@ -60,7 +60,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         {
             var setme = "hi";
             IGenerator<string> defgen = new DefaultGenerator<string>(setme);
-            var checkme = (string) defgen.Generate();
+            var checkme = (string)defgen.Generate();
             Assert.IsNotNull(checkme);
             Assert.AreEqual(checkme, setme);
         }
@@ -69,7 +69,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void DoubleGeneratorWithDefaultValues()
         {
             IGenerator<double> doublegen = new DoubleGenerator();
-            var checkme = (double) doublegen.Generate();
+            var checkme = (double)doublegen.Generate();
             Assert.IsNotNull(checkme);
             Assert.That(checkme, Is.InRange(0.00, 100.00));
         }
@@ -84,7 +84,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void IntegerGeneratorWithDefaultTest()
         {
             IGenerator<int> intgen = new IntegerGenerator();
-            var checkme = (int) intgen.Generate();
+            var checkme = (int)intgen.Generate();
             Assert.IsNotNull(checkme);
             Assert.That(checkme, Is.InRange(0, 100));
         }
@@ -95,7 +95,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             var min = 5;
             var max = 20;
             IGenerator<int> intgen = new IntegerGenerator(min, max);
-            var checkme = (int) intgen.Generate();
+            var checkme = (int)intgen.Generate();
             Assert.IsNotNull(checkme);
             Assert.That(checkme, Is.InRange(min, max));
         }
@@ -108,7 +108,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             testlist.Add("yay");
             testlist.Add("nay");
             IGenerator<string> listgen = new FromListGetSingleGenerator<string>(testlist);
-            var checkme = (string) listgen.Generate();
+            var checkme = (string)listgen.Generate();
             Assert.IsNotNull(checkme);
             Assert.IsTrue(testlist.Contains(checkme));
         }
@@ -117,7 +117,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void NullGeneratorTest()
         {
             IGenerator<object> nullgen = new NullGenerator();
-            var checkme = (string) nullgen.Generate();
+            var checkme = (string)nullgen.Generate();
             Assert.IsNull(checkme);
         }
 
@@ -134,7 +134,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void AmericanPhoneGeneratorTest()
         {
             IGenerator<string> phonegen = new AmericanPhoneGenerator();
-            var phone = (string) phonegen.Generate();
+            var phone = (string)phonegen.Generate();
             Assert.IsNotNull(phone);
             Assert.IsTrue(CheckPhone(phone));
         }
@@ -149,7 +149,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void AmericanPostalCodeGenerator()
         {
             IGenerator<string> postalgen = new AmericanPostalCodeGenerator(1);
-            var zipcode = (string) postalgen.Generate();
+            var zipcode = (string)postalgen.Generate();
             Assert.IsNotNull(zipcode);
             Assert.IsTrue(IsAmericanPostalCodeValid(zipcode));
         }
@@ -167,7 +167,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void TextGeneratorTest()
         {
             IGenerator<string> textgen = new TextGenerator();
-            var text = (string) textgen.Generate();
+            var text = (string)textgen.Generate();
             Assert.IsNotNull(text);
         }
 
@@ -176,7 +176,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void AmericanAddressGeneratorTest()
         {
             IGenerator<string> americanaddy = new AmericanAddressGenerator();
-            var address = (string) americanaddy.Generate();
+            var address = (string)americanaddy.Generate();
             Assert.IsNotNull(address);
         }
 
@@ -185,7 +185,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void AmericanCityGeneratorTest()
         {
             IGenerator<string> americancity = new AmericanCityGenerator();
-            var city = (string) americancity.Generate();
+            var city = (string)americancity.Generate();
             Assert.IsNotNull(city);
         }
 
@@ -193,7 +193,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void AmericanStateGeneratorTest()
         {
             IGenerator<string> americanstate = new AmericanStateGenerator();
-            var state = (string) americanstate.Generate();
+            var state = (string)americanstate.Generate();
             Assert.IsNotNull(state);
         }
 
@@ -209,7 +209,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void IPAddressGeneratorTest()
         {
             IGenerator<string> ipaddress = new IPAddressGenerator();
-            var ipaddy = (string) ipaddress.Generate();
+            var ipaddy = (string)ipaddress.Generate();
             Assert.IsNotNull(ipaddy);
             Assert.IsTrue(IsValidIPAddress(ipaddy));
         }
@@ -224,7 +224,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void WwebsiteAddressGeneratorTest()
         {
             IGenerator<string> websitegen = new WebsiteGenerator();
-            var site = (string) websitegen.Generate();
+            var site = (string)websitegen.Generate();
             Assert.IsNotNull(site);
             Assert.IsTrue(IsWebsiteAddressValid(site));
         }
@@ -233,7 +233,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void GenderGenerator()
         {
             IGenerator<string> gendergenerator = new GenderGenerator();
-            var gender = (string) gendergenerator.Generate();
+            var gender = (string)gendergenerator.Generate();
             Assert.IsNotNull(gender);
         }
 
@@ -241,7 +241,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void CreditCardTypeGenerator()
         {
             IGenerator<string> cardtypegenerator = new CreditCardTypeGenerator();
-            var cardtype = (string) cardtypegenerator.Generate();
+            var cardtype = (string)cardtypegenerator.Generate();
             Assert.IsNotNull(cardtype);
         }
 
@@ -249,7 +249,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void CountryCodeGenerator()
         {
             IGenerator<string> countrycodegenerator = new CountryCodeGenerator();
-            var countrycode = (string) countrycodegenerator.Generate();
+            var countrycode = (string)countrycodegenerator.Generate();
             Assert.IsNotNull(countrycode);
         }
 
@@ -265,7 +265,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void EmailAddressGenerator()
         {
             IGenerator<string> emailaddressgenerator = new EmailAddressGenerator();
-            var emailaddy = (string) emailaddressgenerator.Generate();
+            var emailaddy = (string)emailaddressgenerator.Generate();
             Assert.IsNotNull(emailaddy);
             Assert.IsTrue(IsEmailAddressValid(emailaddy));
         }
@@ -274,17 +274,17 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void BooleanGenerator()
         {
             IGenerator<bool> booleangenerator = new BooleanGenerator();
-            var boolvalue = (bool) booleangenerator.Generate();
+            var boolvalue = (bool)booleangenerator.Generate();
             Assert.IsNotNull(boolvalue);
             Assert.IsInstanceOf<bool>(boolvalue);
-            
+
         }
 
         [Test]
         public void FedExTrackingNumberGenerator()
         {
             IGenerator<string> trackingnumbergenerator = new TrackingNumberGenerator("FedEx");
-            var tracknumber = (string) trackingnumbergenerator.Generate();
+            var tracknumber = (string)trackingnumbergenerator.Generate();
             Assert.IsNotNull(tracknumber);
             Assert.IsTrue(tracknumber.Length == 15);
             Assert.That(tracknumber, Does.StartWith("4"));
@@ -294,7 +294,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void UPSTrackingNumberGenerator()
         {
             IGenerator<string> trackingnumbergenerator = new TrackingNumberGenerator("UPS");
-            var tracknumber = (string) trackingnumbergenerator.Generate();
+            var tracknumber = (string)trackingnumbergenerator.Generate();
             Assert.IsNotNull(tracknumber);
             Assert.IsTrue(tracknumber.Length == 20);
             Assert.That(tracknumber, Does.StartWith("1Z"));
@@ -304,7 +304,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void USPSTrackingNumberGenerator()
         {
             IGenerator<string> trackingnumbergenerator = new TrackingNumberGenerator("USPS");
-            var tracknumber = (string) trackingnumbergenerator.Generate();
+            var tracknumber = (string)trackingnumbergenerator.Generate();
             Assert.IsNotNull(tracknumber);
             Assert.IsTrue(tracknumber.Length == 22);
             Assert.That(tracknumber, Does.StartWith("91"));
@@ -314,7 +314,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void CanGetDefaultCCVFromGenerator()
         {
             IGenerator<string> ccvGenerator = new CCVGenerator("");
-            var ccv = (string) ccvGenerator.Generate();
+            var ccv = (string)ccvGenerator.Generate();
             Assert.IsNotNull(ccv);
         }
 
@@ -322,7 +322,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         public void PasswordWithDefaultLengthGenerator()
         {
             IGenerator<string> pwGen = new PasswordGenerator();
-            var pw = (string) pwGen.Generate();
+            var pw = (string)pwGen.Generate();
             Assert.IsNotNull(pw);
             Assert.IsTrue(pw.Length == 10);
         }
@@ -332,7 +332,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
         {
             var length = 99;
             IGenerator<string> pwGen = new PasswordGenerator(length);
-            var pw = (string) pwGen.Generate();
+            var pw = (string)pwGen.Generate();
             Assert.IsNotNull(pw);
             Assert.AreEqual(length, pw.Length);
         }
@@ -368,6 +368,52 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             IGenerator<string> unitedKingdomCountyGenerator = new UnitedKingdomPostCodeGenerator();
             var county = (string)unitedKingdomCountyGenerator.Generate();
             Assert.IsNotNull(county);
+        }
+
+        [Test]
+        public void NullableBooleanGenerator()
+        {
+            var booleangenerator = new NullableBooleanGenerator(false);
+            var boolvalue = booleangenerator.Generate();
+            Assert.IsNotNull(boolvalue);
+            Assert.IsInstanceOf<bool?>(boolvalue);
+        }
+
+        [Test]
+        public void NullableDateTimeGenerator()
+        {
+            var dateTimegenerator = new NullableDateTimeGenerator(false);
+            var dateTimevalue = dateTimegenerator.Generate();
+            Assert.IsNotNull(dateTimevalue);
+            Assert.IsInstanceOf<DateTime?>(dateTimevalue);
+        }
+
+        [Test]
+        public void NullableDoubleGenerator()
+        {
+            var doublegenerator = new NullableDoubleGenerator(false);
+            var doublevalue = doublegenerator.Generate();
+            Assert.IsNotNull(doublevalue);
+            Assert.IsInstanceOf<double?>(doublevalue);
+        }
+
+        [Test]
+        public void NullableGuidGenerator()
+        {
+            var guidgenerator = new NullableGuidGenerator(false);
+            var guidvalue = guidgenerator.Generate();
+            Assert.IsNotNull(guidvalue);
+            Assert.IsInstanceOf<Guid?>(guidvalue);
+        }
+
+        [Test]
+        public void NullableIntegerGenerator()
+        {
+            var intgenerator = new NullableIntegerGenerator(false);
+            var intvalue = intgenerator.Generate();
+            Assert.IsNotNull(intvalue);
+            Assert.IsInstanceOf<int?>(intvalue);
+
         }
     }
 }

--- a/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/GeneratorTests/Generator_Tests.cs
@@ -287,7 +287,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             var tracknumber = (string) trackingnumbergenerator.Generate();
             Assert.IsNotNull(tracknumber);
             Assert.IsTrue(tracknumber.Length == 15);
-            Assert.That(tracknumber, Is.StringStarting("4"));
+            Assert.That(tracknumber, Does.StartWith("4"));
         }
 
         [Test]
@@ -297,7 +297,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             var tracknumber = (string) trackingnumbergenerator.Generate();
             Assert.IsNotNull(tracknumber);
             Assert.IsTrue(tracknumber.Length == 20);
-            Assert.That(tracknumber, Is.StringStarting("1Z"));
+            Assert.That(tracknumber, Does.StartWith("1Z"));
         }
 
         [Test]
@@ -307,7 +307,7 @@ namespace Foundation.ObjectHydrator.Tests.GeneratorTests
             var tracknumber = (string) trackingnumbergenerator.Generate();
             Assert.IsNotNull(tracknumber);
             Assert.IsTrue(tracknumber.Length == 22);
-            Assert.That(tracknumber, Is.StringStarting("91"));
+            Assert.That(tracknumber, Does.StartWith("91"));
         }
 
         [Test]

--- a/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_ComplexCustomer_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_ComplexCustomer_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Foundation.ObjectHydrator.Generators;
 using Foundation.ObjectHydrator.Tests.POCOs;
@@ -112,6 +113,34 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
                 .GetSingle();
 
             Assert.AreEqual(lastNameDefault, hy.LastName);
+        }
+
+        [Test]
+        public void ThrowExceptionForAbstractTypeGeneration()
+        {
+            var abstractGenerator = new TypeGenerator<Animal>();
+            
+            Assert.Throws<MissingMethodException>(() => abstractGenerator.Generate());
+        }
+
+        [Test]
+        public void CanLoadSingleComplexCustomerWithAbstractTypeMapper()
+        {
+            var hy = new Hydrator<ComplexCustomer>();
+
+            var customer = hy.GetSingle();
+
+            Assert.IsNotNull(customer);
+            
+            //As Animal is an abstract class, it will not be instantiate by default
+            Assert.IsNull(customer.Pet, "Abstract class cannot be instantiate");
+
+            //Set up the generator for abstract type
+            hy = hy.With(x => x.Pet, new TypeGenerator<Dog>());
+            customer = hy.GetSingle();
+
+            Assert.IsNotNull(customer.Pet);
+            Assert.IsInstanceOf<Dog>(customer.Pet);
         }
     }
 }

--- a/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_PetShop_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_PetShop_Tests.cs
@@ -1,0 +1,65 @@
+﻿using Foundation.ObjectHydrator.Generators;
+using Foundation.ObjectHydrator.Tests.POCOs;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Foundation.ObjectHydrator.Tests.HydratorTests
+{
+    [TestFixture]
+    public class Hydrator_PetShop_Tests
+    {
+        [Test]
+        public void Test_Covariance()
+        {
+            var hy = new Hydrator<PetShop>();
+            var shop = hy.GetSingle();
+
+            Assert.IsNotNull(shop);
+            //By default, no instantiation for interfaces and abstract types
+            Assert.IsNull(shop.AnimalEnumerable);
+            Assert.IsNull(shop.AnimalList);
+            Assert.IsNull(shop.CatEnumerable);
+
+            //Dog list should be initialized as it is type of generic List
+            Assert.IsNotNull(shop.DogList);
+            CollectionAssert.IsEmpty(shop.DogList);
+
+            //setup generators
+            hy = hy.With(x => x.AnimalEnumerable, new ListGenerator<Dog>(2)) //Can setup as IEnumerable supports covariance
+                .With(x => x.CatEnumerable, new ListGenerator<Cat>(2)) //Can setup as no covariance required
+                .With(x => x.CatList, new ListGenerator<Cat>(3)); //Can setup List type as no covarinace required
+                                                                  //.With(x=>x.AnimalList, new ListGenerator<Cat>(2)) --Cannot setup as IList type doesn't support covariance
+                                                                  //.With(x=>x.DogList, new ListGenerator<Dog>(2)) --Cannot setup as List type doesn't support covariance
+
+            shop = hy.GetSingle();
+
+            Assert.IsNotNull(shop);
+
+            //Ienumerable types must be instantiated
+            Assert.IsNotNull(shop.AnimalEnumerable);
+            Assert.AreEqual(2, shop.AnimalEnumerable.Count());
+            CollectionAssert.AllItemsAreInstancesOfType(shop.AnimalEnumerable, typeof(Dog));
+            Assert.IsNotNull(shop.CatEnumerable);
+            Assert.AreEqual(2, shop.CatEnumerable.Count());
+            CollectionAssert.AllItemsAreInstancesOfType(shop.CatEnumerable, typeof(Cat));
+
+            //List type with no covariance should be instantiated
+            Assert.IsNotNull(shop.CatList);
+            Assert.AreEqual(3, shop.CatList.Count);
+            CollectionAssert.AllItemsAreInstancesOfType(shop.CatList, typeof(Cat));
+
+            //As we have seen that we cannot setup IList and List types in case of covariance
+            //We can use the following apporach for such types
+            shop.AnimalList = new List<Animal>(new Hydrator<Cat>().GetList(2));
+            shop.DogList = new List<Animal>(new Hydrator<Dog>().GetList(2));
+
+            Assert.IsNotNull(shop.DogList);
+            Assert.AreEqual(2, shop.DogList.Count);
+            CollectionAssert.AllItemsAreInstancesOfType(shop.DogList, typeof(Dog));
+            Assert.IsNotNull(shop.AnimalList);
+            Assert.AreEqual(2, shop.AnimalList.Count);
+            CollectionAssert.AllItemsAreInstancesOfType(shop.AnimalList, typeof(Cat));
+        }
+    }
+}

--- a/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_SimpleCustomer_Tests.cs
+++ b/Foundation.ObjectHydrator.Tests/HydratorTests/Hydrator_SimpleCustomer_Tests.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using Foundation.ObjectHydrator.Generators;
+using Foundation.ObjectHydrator.Tests.POCOs;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using NUnit.Framework;
-using Foundation.ObjectHydrator.Generators;
-using Foundation.ObjectHydrator.Tests.POCOs;
 
 namespace Foundation.ObjectHydrator.Tests.HydratorTests
 {
@@ -30,7 +30,7 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
             var customer = hydrator.GetSingle();
 
             Assert.IsTrue(!String.IsNullOrEmpty(customer.Description), "Customer Description should exist.");
-            Assert.IsTrue(customer.Description.Length <= 5,"Length not restricted");
+            Assert.IsTrue(customer.Description.Length <= 5, "Length not restricted");
             DumpSimpleCustomer(customer);
         }
 
@@ -132,7 +132,7 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
                 .WithDouble(x => x.Revenue, decimalPlaces);
             var customer = hydrator.GetSingle();
 
-            var decimalPart = customer.Revenue - (int) customer.Revenue;
+            var decimalPart = customer.Revenue - (int)customer.Revenue;
             Assert.IsTrue(decimalPart >= 0, String.Format("Customer Revenue decimal part is expected."));
 
             DumpSimpleCustomer(customer);
@@ -163,7 +163,7 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
                 .WithDouble(x => x.Revenue, minimum, maximum, decimalPlaces);
 
             var customer = hydrator.GetSingle();
-            var decimalPart = customer.Revenue - (int) customer.Revenue;
+            var decimalPart = customer.Revenue - (int)customer.Revenue;
 
             Assert.That(customer.Revenue, Is.InRange(minimum, maximum));
             Assert.IsTrue(decimalPart >= 0, String.Format("Customer Revenue decimal part is expected."));
@@ -394,7 +394,7 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
             var customer = hydrator.GetSingle();
             Assert.IsNotNull(customer.IsActive);
             Assert.IsInstanceOf<bool>(customer.IsActive);
-            
+
             DumpSimpleCustomer(customer);
         }
 
@@ -463,7 +463,7 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
         [Test]
         public void FromListTest()
         {
-            IList<string> mylist = new List<string>() {"red", "green", "blue", "orange"};
+            IList<string> mylist = new List<string>() { "red", "green", "blue", "orange" };
             var hydrator = new Hydrator<SimpleCustomer>()
                 .FromList(x => x.placeholderstring, mylist);
             var customer = hydrator.GetSingle();
@@ -619,6 +619,17 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
             Assert.IsNotNull(customer.placeholderstring);
         }
 
+        [Test]
+        public void CanGetNullableFields()
+        {
+            var hydrator = new Hydrator<SimpleCustomer>(false);
+            var customer = hydrator.GetSingle();
+            Assert.IsNotNull(customer.RewardPoints);
+            Assert.IsInstanceOf<int?>(customer.RewardPoints);
+
+            DumpSimpleCustomer(customer);
+        }
+
         private void DumpCustomers(IList<SimpleCustomer> customers)
         {
             foreach (SimpleCustomer customer in customers)
@@ -634,7 +645,7 @@ namespace Foundation.ObjectHydrator.Tests.HydratorTests
             {
                 Trace.WriteLine(String.Format("{0} [{1}]", propertyInfo.Name, propertyInfo.GetValue(theObject, null)));
 
-                if (propertyInfo.PropertyType == typeof (byte[]))
+                if (propertyInfo.PropertyType == typeof(byte[]))
                 {
                     var theArray = propertyInfo.GetValue(theObject, null) as byte[];
                     if (theArray != null)

--- a/Foundation.ObjectHydrator.Tests/POCOs/Animal.cs
+++ b/Foundation.ObjectHydrator.Tests/POCOs/Animal.cs
@@ -1,0 +1,18 @@
+﻿namespace Foundation.ObjectHydrator.Tests.POCOs
+{
+    public abstract class Animal
+    {
+        public abstract string Name { get; set; }
+
+    }
+
+    public class Dog : Animal
+    {
+        public override string Name { get; set; }
+    }
+
+    public class Cat : Animal
+    {
+        public override string Name { get; set; }
+    }
+}

--- a/Foundation.ObjectHydrator.Tests/POCOs/ComplexCustomer.cs
+++ b/Foundation.ObjectHydrator.Tests/POCOs/ComplexCustomer.cs
@@ -31,13 +31,15 @@ namespace Foundation.ObjectHydrator.Tests.POCOs
         public Address HomeAddress { get; set; }
         public IList<Address> Addresses { get; set; }
 
-        
+
 
         public string HomePhone { get; set; }
         public string WorkPhone { get; set; }
         public string[] PhoneNumbers { get; set; }
 
         public CustomerType Type { get; set; }
+
+        public Animal Pet { get; set; }
 
     }
 }

--- a/Foundation.ObjectHydrator.Tests/POCOs/PetShop.cs
+++ b/Foundation.ObjectHydrator.Tests/POCOs/PetShop.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Foundation.ObjectHydrator.Tests.POCOs
+{
+    /// <summary>
+    /// POCO to test covarience feature of Generator
+    /// </summary>
+    public class PetShop
+    {
+        public IEnumerable<Animal> AnimalEnumerable { get; set; }
+
+        public IList<Animal> AnimalList { get; set; }
+
+        public List<Animal> DogList { get; set; }
+
+        public IEnumerable<Cat> CatEnumerable { get; set; }
+
+        public IList<Cat> CatList { get; set; }
+    }
+}

--- a/Foundation.ObjectHydrator.Tests/POCOs/SimpleCustomer.cs
+++ b/Foundation.ObjectHydrator.Tests/POCOs/SimpleCustomer.cs
@@ -4,7 +4,7 @@ namespace Foundation.ObjectHydrator.Tests.POCOs
 {
     public class SimpleCustomer
     {
-        
+
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Company { get; set; }
@@ -51,7 +51,9 @@ namespace Foundation.ObjectHydrator.Tests.POCOs
                 _password = value;
             }
         }
-        
+
         public string placeholderstring { get; set; }
+
+        public int? RewardPoints { get; set; }
     }
 }

--- a/Foundation.ObjectHydrator/DefaultTypeMap.cs
+++ b/Foundation.ObjectHydrator/DefaultTypeMap.cs
@@ -14,16 +14,19 @@ namespace Foundation.ObjectHydrator
             Add(new Map<int?>().Using(new NullableIntegerGenerator(allowNulls)));
             Add(new Map<bool?>().Using(new NullableBooleanGenerator(allowNulls)));
             Add(new Map<Guid?>().Using(new NullableGuidGenerator(allowNulls)));
+            Add(new Map<decimal?>().Using(new NullableDecimalGenerator(allowNulls)));
+
 
             Add(new Map<DateTime>().Using(new DateTimeGenerator()));
             Add(new Map<double>().Using(new DoubleGenerator()));
+            Add(new Map<decimal>().Using(new DecimalGenerator()));
             Add(new Map<Double>().Using(new DoubleGenerator()));
             Add(new Map<int>().Using(new IntegerGenerator()));
             Add(new Map<Int32>().Using(new IntegerGenerator()));
             Add(new Map<bool>().Using(new BooleanGenerator()));
             Add(new Map<Guid>().Using(new GuidGenerator()));
             Add(new Map<byte[]>().Using(new ByteArrayGenerator(8)));
-            Add(new EnumMap());
+            //Add(new EnumMap()); --It is not working as expected.
             Add(new Map<string>()
                     .Matching(info => info.Name.ToLower() == "firstname" || info.Name.ToLower() == "fname")
                     .Using(new FirstNameGenerator()));

--- a/Foundation.ObjectHydrator/DefaultTypeMap.cs
+++ b/Foundation.ObjectHydrator/DefaultTypeMap.cs
@@ -1,14 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Foundation.ObjectHydrator.Generators;
 using Foundation.ObjectHydrator.Interfaces;
-using Foundation.ObjectHydrator.Generators;
+using System;
+using System.Collections.Generic;
 
 namespace Foundation.ObjectHydrator
 {
-    public class DefaultTypeMap:List<IMap>
+    public class DefaultTypeMap : List<IMap>
     {
-        public DefaultTypeMap()
+        public DefaultTypeMap(bool allowNulls)
         {
+            Add(new Map<DateTime?>().Using(new NullableDateTimeGenerator(allowNulls)));
+            Add(new Map<double?>().Using(new NullableDoubleGenerator(allowNulls)));
+            Add(new Map<int?>().Using(new NullableIntegerGenerator(allowNulls)));
+            Add(new Map<bool?>().Using(new NullableBooleanGenerator(allowNulls)));
+            Add(new Map<Guid?>().Using(new NullableGuidGenerator(allowNulls)));
+
             Add(new Map<DateTime>().Using(new DateTimeGenerator()));
             Add(new Map<double>().Using(new DoubleGenerator()));
             Add(new Map<Double>().Using(new DoubleGenerator()));

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
@@ -94,6 +94,11 @@
     <Compile Include="Generators\FromListGetListGenerator.cs" />
     <Compile Include="Generators\FromListGetSingleGenerator.cs" />
     <Compile Include="Generators\Generator.cs" />
+    <Compile Include="Generators\NullableBooleanGenerator.cs" />
+    <Compile Include="Generators\NullableDateTimeGenerator.cs" />
+    <Compile Include="Generators\NullableDoubleGenerator.cs" />
+    <Compile Include="Generators\NullableGuidGenerator.cs" />
+    <Compile Include="Generators\NullableIntegerGenerator.cs" />
     <Compile Include="Generators\PasswordGenerator.cs" />
     <Compile Include="Generators\TrackingNumberGenerator.cs" />
     <Compile Include="Generators\CountryCodeGenerator.cs" />

--- a/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
+++ b/Foundation.ObjectHydrator/Foundation.ObjectHydrator.csproj
@@ -91,12 +91,15 @@
     <Compile Include="Generators\ByteArrayGenerator.cs" />
     <Compile Include="Generators\CCVGenerator.cs" />
     <Compile Include="Generators\CompanyNameGenerator.cs" />
+    <Compile Include="Generators\DecimalGenerator.cs" />
     <Compile Include="Generators\FromListGetListGenerator.cs" />
     <Compile Include="Generators\FromListGetSingleGenerator.cs" />
     <Compile Include="Generators\Generator.cs" />
     <Compile Include="Generators\NullableBooleanGenerator.cs" />
     <Compile Include="Generators\NullableDateTimeGenerator.cs" />
+    <Compile Include="Generators\NullableDecimalGenerator.cs" />
     <Compile Include="Generators\NullableDoubleGenerator.cs" />
+    <Compile Include="Generators\NullableEnumGenerator.cs" />
     <Compile Include="Generators\NullableGuidGenerator.cs" />
     <Compile Include="Generators\NullableIntegerGenerator.cs" />
     <Compile Include="Generators\PasswordGenerator.cs" />

--- a/Foundation.ObjectHydrator/Generators/DecimalGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/DecimalGenerator.cs
@@ -1,0 +1,69 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class DecimalGenerator : IGenerator<decimal>
+    {
+        readonly Random _random;
+
+        public decimal MinimumValue { get; set; }
+        public decimal MaximumValue { get; set; }
+        public int DecimalPlaces { get; set; }
+
+        public DecimalGenerator()
+            : this(0.0m, 100.00m)
+        { }
+
+        public DecimalGenerator(int decimalPlaces) : this(0.0m, 100.00m, decimalPlaces)
+        {
+
+        }
+
+        public DecimalGenerator(decimal minimumValue, decimal maximumValue)
+            : this(minimumValue, maximumValue, 2)
+        { }
+
+
+        public DecimalGenerator(decimal minimumValue, decimal maximumValue, int decimalPlaces)
+        {
+            if (minimumValue > maximumValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumValue), minimumValue, "minimumValue must be <= maximumValue");
+            }
+
+            if (decimalPlaces > 5)
+            {
+                throw new ArgumentOutOfRangeException(nameof(decimalPlaces), decimalPlaces, "decimalPlaces must be <=5;");
+            }
+
+            MinimumValue = minimumValue;
+            MaximumValue = maximumValue;
+            DecimalPlaces = decimalPlaces;
+
+            _random = RandomSingleton.Instance.Random;
+        }
+
+        public decimal Generate()
+        {
+            // The offset adjustment to get down to an Int minimum value
+            var offset = MinimumValue - Math.Floor(MinimumValue);
+            var adjustedMinimum = MinimumValue - offset;
+            var adjustedMaximum = MaximumValue - offset;
+
+            double toReturn = _random.Next((int)adjustedMinimum, (int)adjustedMaximum);
+            var decimalPart = _random.NextDouble();
+            decimalPart *= Math.Pow(10, DecimalPlaces);
+            decimalPart = (int)decimalPart;
+
+            toReturn += decimalPart / Math.Pow(10, DecimalPlaces);
+
+            // Now, add back the offset
+            toReturn += (double)offset;
+
+            return (decimal)toReturn;
+        }
+
+
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/Generator.cs
+++ b/Foundation.ObjectHydrator/Generators/Generator.cs
@@ -18,12 +18,24 @@ namespace Foundation.ObjectHydrator.Generators
         {
             if (_info.PropertyType.IsArray)
             {
-                return Array.CreateInstance(_info.PropertyType.GetElementType(), 0);
+                var type = _info.PropertyType.GetElementType();
+
+                if (CanConstruct(type))
+                {
+                    return Array.CreateInstance(type, 0);
+                }
             }
 
-            return Activator.CreateInstance(_info.PropertyType);
+            return CanConstruct(_info.PropertyType) ? Activator.CreateInstance(_info.PropertyType) : null;
         }
 
         #endregion
+
+
+
+        private static bool CanConstruct(Type type)
+        {
+            return type != null && !type.IsAbstract && type.GetConstructor(Type.EmptyTypes) != null;
+        }
     }
 }

--- a/Foundation.ObjectHydrator/Generators/Generator.cs
+++ b/Foundation.ObjectHydrator/Generators/Generator.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using Foundation.ObjectHydrator.Interfaces;
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
 using System.Reflection;
 
 namespace Foundation.ObjectHydrator.Generators
 {
-    public class Generator:IGenerator
+    public class Generator : IGenerator<object>
     {
         private readonly PropertyInfo _info;
 

--- a/Foundation.ObjectHydrator/Generators/NullableBooleanGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableBooleanGenerator.cs
@@ -1,0 +1,31 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableBooleanGenerator : IGenerator<bool?>
+    {
+        private readonly Random _random;
+        private readonly bool _allowNulls;
+        public NullableBooleanGenerator(bool allowNulls)
+        {
+            _allowNulls = allowNulls;
+            _random = RandomSingleton.Instance.Random;
+        }
+
+        #region IGenerator Members
+
+        public bool? Generate()
+        {
+            var seed = _random.Next(0, _allowNulls ? 3 : 2);
+
+            if (seed > 1)
+            {
+                return null;
+            }
+            return Convert.ToBoolean(seed);
+        }
+
+        #endregion
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableDateTimeGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableDateTimeGenerator.cs
@@ -1,0 +1,43 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableDateTimeGenerator : IGenerator<DateTime?>
+    {
+        readonly Random _random;
+        private readonly bool _allowNulls;
+        public DateTime MinimumValue { get; }
+        public DateTime MaximumValue { get; }
+
+        public NullableDateTimeGenerator(bool allowNulls)
+            : this(DateTime.Now.AddYears(-10), DateTime.Now.AddYears(10), allowNulls)
+        { }
+
+
+        public NullableDateTimeGenerator(DateTime minimumValue, DateTime maximumValue, bool allowNulls)
+        {
+            MinimumValue = minimumValue;
+            MaximumValue = maximumValue;
+            _allowNulls = allowNulls;
+
+            _random = RandomSingleton.Instance.Random;
+        }
+
+        public DateTime? Generate()
+        {
+            var timeSpan = MaximumValue - MinimumValue;
+            var max = _allowNulls ? timeSpan.Days + 1 : timeSpan.Days;
+            var dayOffset = _random.Next(0, max);
+
+            //null will be represneted by MaximumValue 
+            if (dayOffset == timeSpan.Days)
+            {
+                return null;
+            }
+
+            return MinimumValue.Date.AddDays(dayOffset) + new TimeSpan(_random.Next(0, 24), _random.Next(0, 59), _random.Next(0, 59));
+
+        }
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableDecimalGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableDecimalGenerator.cs
@@ -1,0 +1,79 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableDecimalGenerator : IGenerator<decimal?>
+    {
+        readonly Random _random;
+        private readonly bool _allowNulls;
+        public decimal MinimumValue { get; set; }
+        public decimal MaximumValue { get; set; }
+        public int DecimalPlaces { get; set; }
+
+        public NullableDecimalGenerator(bool allowNulls)
+            : this(0.0m, 100.00m, allowNulls)
+        { }
+
+        public NullableDecimalGenerator(int decimalPlaces, bool allowNulls) : this(0.0m, 100.00m, decimalPlaces, allowNulls)
+        {
+
+        }
+
+        public NullableDecimalGenerator(decimal minimumValue, decimal maximumValue, bool allowNulls)
+            : this(minimumValue, maximumValue, 2, allowNulls)
+        { }
+
+
+        public NullableDecimalGenerator(decimal minimumValue, decimal maximumValue, int decimalPlaces, bool allowNulls)
+        {
+            if (minimumValue > maximumValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumValue), minimumValue, "minimumValue must be <= maximumValue");
+            }
+
+            if (decimalPlaces > 5)
+            {
+                throw new ArgumentOutOfRangeException(nameof(decimalPlaces), decimalPlaces, "decimalPlaces must be <=5;");
+            }
+
+            MinimumValue = minimumValue;
+            MaximumValue = maximumValue;
+            DecimalPlaces = decimalPlaces;
+            _allowNulls = allowNulls;
+
+            _random = RandomSingleton.Instance.Random;
+        }
+
+        public decimal? Generate()
+        {
+            // The offset adjustment to get down to an Int minimum value
+            var offset = MinimumValue - Math.Floor(MinimumValue);
+            var adjustedMinimum = MinimumValue - offset;
+            var adjustedMaximum = MaximumValue - offset;
+
+            var max = _allowNulls ? (int)adjustedMaximum + 1 : (int)adjustedMaximum;
+            var nextRandomVal = _random.Next((int)adjustedMinimum, max);
+
+            if (nextRandomVal == (int)adjustedMaximum)
+            {
+                return null;
+            }
+
+            double toReturn = nextRandomVal;
+
+            var decimalPart = _random.NextDouble();
+            decimalPart *= Math.Pow(10, DecimalPlaces);
+            decimalPart = (int)decimalPart;
+
+            toReturn += decimalPart / Math.Pow(10, DecimalPlaces);
+
+            // Now, add back the offset
+            toReturn += (double)offset;
+
+            return (decimal)toReturn;
+        }
+
+
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableDoubleGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableDoubleGenerator.cs
@@ -1,0 +1,82 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableDoubleGenerator : IGenerator<double?>
+    {
+        readonly Random _random;
+        private readonly bool _allowNulls;
+
+        public double MinimumValue { get; set; }
+        public double MaximumValue { get; set; }
+        public int DecimalPlaces { get; set; }
+
+        public NullableDoubleGenerator(bool allowNulls)
+            : this(0.0, 100, allowNulls)
+        { }
+
+        public NullableDoubleGenerator(int decimalPlaces, bool allowNulls) : this(0.0, 100.00, decimalPlaces, allowNulls)
+        {
+
+        }
+
+        public NullableDoubleGenerator(double minimumValue, double maximumValue, bool allowNulls)
+            : this(minimumValue, maximumValue, 2, allowNulls)
+        { }
+
+
+        public NullableDoubleGenerator(double minimumValue, double maximumValue, int decimalPlaces, bool allowNulls)
+        {
+            if (minimumValue > maximumValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumValue), minimumValue, "minimumValue must be <= maximumValue");
+            }
+
+            if (decimalPlaces > 5)
+            {
+                throw new ArgumentOutOfRangeException(nameof(decimalPlaces), decimalPlaces, "decimalPlaces must be <=5;");
+            }
+
+            MinimumValue = minimumValue;
+            MaximumValue = maximumValue;
+            DecimalPlaces = decimalPlaces;
+            _allowNulls = allowNulls;
+
+            _random = RandomSingleton.Instance.Random;
+        }
+
+        public double? Generate()
+        {
+
+            // The offset adjustment to get down to an Int minimum value
+            var offset = MinimumValue - Math.Floor(MinimumValue);
+            var adjustedMinimum = MinimumValue - offset;
+            var adjustedMaximum = MaximumValue - offset;
+
+            var max = _allowNulls ? (int)adjustedMaximum + 1 : (int)adjustedMaximum;
+
+            var nextRandomVal = _random.Next((int)adjustedMinimum, max);
+
+            if (nextRandomVal == (int)adjustedMaximum)
+            {
+                return null;
+            }
+
+            double toReturn = nextRandomVal;
+
+            var decimalPart = _random.NextDouble();
+            decimalPart *= Math.Pow(10, DecimalPlaces);
+            decimalPart = (int)decimalPart;
+
+            toReturn += decimalPart / Math.Pow(10, DecimalPlaces);
+
+            // Now, add back the offset
+            toReturn += offset;
+
+            return toReturn;
+        }
+
+
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableEnumGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableEnumGenerator.cs
@@ -1,0 +1,32 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableEnumGenerator : IGenerator<object>
+    {
+        readonly Random _random;
+        readonly Array _enumValues;
+        private readonly bool _allowNulls;
+
+        public NullableEnumGenerator(Array enumValues, bool allowNulls)
+        {
+            _enumValues = enumValues;
+            _allowNulls = allowNulls;
+            _random = RandomSingleton.Instance.Random;
+
+        }
+
+        public object Generate()
+        {
+            var seed = _random.Next(0, _allowNulls ? _enumValues.Length + 1 : _enumValues.Length);
+
+            if (seed == _enumValues.Length)
+            {
+                return null;
+            }
+
+            return _enumValues.GetValue(seed);
+        }
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableGuidGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableGuidGenerator.cs
@@ -1,0 +1,30 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableGuidGenerator : IGenerator<Guid?>
+    {
+        private readonly Random _random = RandomSingleton.Instance.Random;
+        private readonly bool _allowNulls;
+
+        public NullableGuidGenerator(bool allowNulls)
+        {
+            _allowNulls = allowNulls;
+        }
+
+        #region IGenerator Members
+
+        public Guid? Generate()
+        {
+            if (_random.Next(0, _allowNulls ? 2 : 1) == 1)
+            {
+                return null;
+            }
+
+            return Guid.NewGuid();
+        }
+
+        #endregion
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/NullableIntegerGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/NullableIntegerGenerator.cs
@@ -1,0 +1,40 @@
+﻿using Foundation.ObjectHydrator.Interfaces;
+using System;
+
+namespace Foundation.ObjectHydrator.Generators
+{
+    public class NullableIntegerGenerator : IGenerator<int?>
+    {
+        readonly Random _random;
+        private readonly bool _allowNulls;
+
+        public int MinimumValue { get; set; }
+        public int MaximumValue { get; set; }
+
+        public NullableIntegerGenerator(bool allowNulls)
+            : this(0, 100, allowNulls)
+        { }
+
+        public NullableIntegerGenerator(int minimumValue, int maximumValue, bool allowNulls)
+        {
+            MinimumValue = minimumValue;
+            MaximumValue = maximumValue;
+            _allowNulls = allowNulls;
+
+            _random = RandomSingleton.Instance.Random;
+        }
+
+        public int? Generate()
+        {
+            var result = _random.Next(MinimumValue, _allowNulls ? MaximumValue + 1 : MaximumValue);
+
+            //null will be represented by MaximumValue
+            if (result == MaximumValue)
+            {
+                return null;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Foundation.ObjectHydrator/Generators/UnitedKingdomPostcodeGenerator.cs
+++ b/Foundation.ObjectHydrator/Generators/UnitedKingdomPostcodeGenerator.cs
@@ -3118,8 +3118,6 @@ namespace Foundation.ObjectHydrator.Generators
 
         public string Generate()
         {
-            var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
             var postCode = new StringBuilder();
 
             postCode.Append(_postcodePrefix[_random.Next(0, _postcodePrefix.Count)]);

--- a/Foundation.ObjectHydrator/Hydrator.cs
+++ b/Foundation.ObjectHydrator/Hydrator.cs
@@ -231,6 +231,27 @@ namespace Foundation.ObjectHydrator
 
         }
 
+        public Hydrator<T> WithDecimal<TProperty>(Expression<Func<T, TProperty>> expression, int decimalPlaces)
+        {
+            var gen = (IGenerator<TProperty>)new DecimalGenerator(decimalPlaces);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+        public Hydrator<T> WithDecimal<TProperty>(Expression<Func<T, TProperty>> expression, decimal minimum, decimal maximum)
+        {
+            var gen = (IGenerator<TProperty>)new DecimalGenerator(minimum, maximum);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+
+
+        public Hydrator<T> WithDecimal<TProperty>(Expression<Func<T, TProperty>> expression, decimal minimum, decimal maximum, int decimalPlaces)
+        {
+            var gen = (IGenerator<TProperty>)new DecimalGenerator(minimum, maximum, decimalPlaces);
+            SetPropertyMap(expression, gen);
+
+            return this;
+        }
 
 
         #region WithCustomGeneratorTypes
@@ -514,6 +535,36 @@ namespace Foundation.ObjectHydrator
 
             return this;
         }
+
+        public Hydrator<T> WithNullableDecimal<TProperty>(Expression<Func<T, TProperty>> expression, int decimalPlaces, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableDecimalGenerator(decimalPlaces, allowNulls);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+        public Hydrator<T> WithNullableDecimal<TProperty>(Expression<Func<T, TProperty>> expression, decimal minimum, decimal maximum, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableDecimalGenerator(minimum, maximum, allowNulls);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+
+
+        public Hydrator<T> WithNullableDecimal<TProperty>(Expression<Func<T, TProperty>> expression, decimal minimum, decimal maximum, int decimalPlaces, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableDecimalGenerator(minimum, maximum, decimalPlaces, allowNulls);
+            SetPropertyMap(expression, gen);
+
+            return this;
+        }
+
+        public Hydrator<T> WithNullableEnum<TProperty>(Expression<Func<T, TProperty>> expression, Array enumValues, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableEnumGenerator(enumValues, allowNulls);
+            SetPropertyMap(expression, gen);
+            return this;
+
+        }
         #endregion
 
         /// <summary>
@@ -599,7 +650,7 @@ namespace Foundation.ObjectHydrator
                     }
                     else if (!propertyInfo.PropertyType.IsInterface)
                     {
-                        propertyMap[propertyInfo.Name] = new Mapping(propertyInfo, new Generator(propertyInfo));
+                        propertyMap[propertyInfo.Name] = new Mapping(propertyInfo, _allowNulls);
                     }
                 }
             }

--- a/Foundation.ObjectHydrator/Hydrator.cs
+++ b/Foundation.ObjectHydrator/Hydrator.cs
@@ -1,27 +1,28 @@
-﻿using System;
+﻿using Foundation.ObjectHydrator.Generators;
+using Foundation.ObjectHydrator.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using Foundation.ObjectHydrator.Generators;
-using Foundation.ObjectHydrator.Interfaces;
 using System.Linq.Expressions;
+using System.Reflection;
 
 
 namespace Foundation.ObjectHydrator
 {
-    public class Hydrator<T>:IGenerator<T>
+    public class Hydrator<T> : IGenerator<T>
     {
         readonly Type typeOfT = null;
         readonly IDictionary<string, IMapping> propertyMap;
         private readonly IList<IMap> typeMap;
         private IList<IMap> defaultTypeMap;
-
+        private readonly bool _allowNulls;
 
         #region Ctors
 
-        public Hydrator()
-            : this(new DefaultTypeMap())
+        public Hydrator(bool allowNulls = true)
+            : this(new DefaultTypeMap(allowNulls))
         {
+            _allowNulls = allowNulls;
         }
 
         public Hydrator(IList<IMap> defaultMap)
@@ -77,9 +78,9 @@ namespace Foundation.ObjectHydrator
         public IList<T> GetList()
         {
             int length;
-            
+
             length = Random.Next(1, 10);
-            
+
             return GetList(length);
         }
 
@@ -165,7 +166,7 @@ namespace Foundation.ObjectHydrator
             return this;
         }
 
-        public Hydrator<T> WithCustomGenerator<TProperty>(Expression<Func<T,TProperty>> expression, IGenerator<TProperty> customgenerator)
+        public Hydrator<T> WithCustomGenerator<TProperty>(Expression<Func<T, TProperty>> expression, IGenerator<TProperty> customgenerator)
         {
             SetPropertyMap(expression, customgenerator);
             return this;
@@ -358,7 +359,7 @@ namespace Foundation.ObjectHydrator
             SetPropertyMap(expression, gen);
             return this;
         }
-        
+
 
 
         /// <summary>
@@ -452,10 +453,10 @@ namespace Foundation.ObjectHydrator
             return this;
 
         }
-        
 
 
-        
+
+
         #endregion
 
         //Not working.
@@ -467,7 +468,54 @@ namespace Foundation.ObjectHydrator
         }
 
         #endregion
-        
+
+        #region WithNullableTypes
+        public Hydrator<T> WithNullableInteger<TProperty>(Expression<Func<T, TProperty>> expression, int minimum, int maximum, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableIntegerGenerator(minimum, maximum, allowNulls);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+
+        public Hydrator<T> WithNullableGuid<TProperty>(Expression<Func<T, TProperty>> expression, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableGuidGenerator(allowNulls);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+
+        public Hydrator<T> WithNullableDate<TProperty>(Expression<Func<T, TProperty>> expression, DateTime minimum, DateTime maximum, bool allowNulls = true)
+        {
+
+            var gen = (IGenerator<TProperty>)new NullableDateTimeGenerator(minimum, maximum, allowNulls);
+            SetPropertyMap(expression, gen);
+
+            return this;
+        }
+
+        public Hydrator<T> WithNullableDouble<TProperty>(Expression<Func<T, TProperty>> expression, int decimalPlaces, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableDoubleGenerator(decimalPlaces, allowNulls);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+        public Hydrator<T> WithNullableDouble<TProperty>(Expression<Func<T, TProperty>> expression, double minimum, double maximum, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableDoubleGenerator(minimum, maximum, allowNulls);
+            SetPropertyMap(expression, gen);
+            return this;
+        }
+
+
+        public Hydrator<T> WithNullableDouble<TProperty>(Expression<Func<T, TProperty>> expression, double minimum, double maximum, int decimalPlaces, bool allowNulls = true)
+        {
+            var gen = (IGenerator<TProperty>)new NullableDoubleGenerator(minimum, maximum, decimalPlaces, allowNulls);
+            SetPropertyMap(expression, gen);
+
+            return this;
+        }
+        #endregion
+
         /// <summary>
         /// Applies a random selection from the passed list to the provided Property Name.
         /// </summary>
@@ -525,8 +573,8 @@ namespace Foundation.ObjectHydrator
             foreach (IMapping mapping in propertyMap.Values)
             {
                 PropertyInfo propertyInfo = instance.GetType().GetProperty(mapping.PropertyName, BindingFlags.Public | BindingFlags.Instance);
-                
-               
+
+
                 if (propertyInfo != null)
                 {
                     propertyInfo.SetValue(instance, mapping.Generate(), null);
@@ -564,7 +612,7 @@ namespace Foundation.ObjectHydrator
                 typeMap.Add(map);
             }
         }
-       
+
     }
 
 }

--- a/Foundation.ObjectHydrator/Hydrator.cs
+++ b/Foundation.ObjectHydrator/Hydrator.cs
@@ -648,7 +648,7 @@ namespace Foundation.ObjectHydrator
                     {
                         propertyMap[propertyInfo.Name] = map.Mapping(propertyInfo);
                     }
-                    else if (!propertyInfo.PropertyType.IsInterface)
+                    else
                     {
                         propertyMap[propertyInfo.Name] = new Mapping(propertyInfo, _allowNulls);
                     }

--- a/Foundation.ObjectHydrator/Interfaces/IGenerator.cs
+++ b/Foundation.ObjectHydrator/Interfaces/IGenerator.cs
@@ -1,11 +1,14 @@
-﻿namespace Foundation.ObjectHydrator.Interfaces
+﻿using System;
+
+namespace Foundation.ObjectHydrator.Interfaces
 {
+    [Obsolete]
     public interface IGenerator
     {
         object Generate();
     }
 
-    public interface IGenerator<T>
+    public interface IGenerator<out T>
     {
         T Generate();
     }

--- a/Foundation.ObjectHydrator/Mapping.cs
+++ b/Foundation.ObjectHydrator/Mapping.cs
@@ -1,10 +1,11 @@
-﻿using System;
-using System.Reflection;
+﻿using Foundation.ObjectHydrator.Generators;
 using Foundation.ObjectHydrator.Interfaces;
+using System;
+using System.Reflection;
 
 namespace Foundation.ObjectHydrator
 {
-    public class Mapping<T>:IMapping
+    public class Mapping<T> : IMapping
     {
         public Mapping(PropertyInfo propertyInfo, IGenerator<T> generator)
         {
@@ -17,10 +18,10 @@ namespace Foundation.ObjectHydrator
                 {
                     System.Attribute attr = (System.Attribute)item;
                     //TODO: Refactor this out to be more flexible and support more annotations
-                    if (attr.GetType()==typeof(System.ComponentModel.DataAnnotations.StringLengthAttribute))
+                    if (attr.GetType() == typeof(System.ComponentModel.DataAnnotations.StringLengthAttribute))
                     {
                         System.ComponentModel.DataAnnotations.StringLengthAttribute sla = (System.ComponentModel.DataAnnotations.StringLengthAttribute)attr;
-                        if (generator.GetType()==typeof(Generators.TextGenerator))
+                        if (generator.GetType() == typeof(Generators.TextGenerator))
                         {
                             generator = (IGenerator<T>)new Generators.TextGenerator(sla.MaximumLength);
                         }
@@ -28,7 +29,7 @@ namespace Foundation.ObjectHydrator
                 }
                 catch (Exception)
                 {
-                    
+
                     throw;
                 }
             }
@@ -47,16 +48,36 @@ namespace Foundation.ObjectHydrator
 
     public class Mapping : IMapping
     {
-        public Mapping(PropertyInfo propertyInfo, IGenerator generator)
+        public Mapping(PropertyInfo propertyInfo, bool allowNulls)
         {
             PropertyName = propertyInfo.Name;
             PropertyInfo = propertyInfo;
-            Generator = generator;
+            Generator = Generator = GetGenerator(propertyInfo, allowNulls);
+        }
+
+        private IGenerator<object> GetGenerator(PropertyInfo propertyInfo, bool allowNulls)
+        {
+            //Check if it is nullable Enum
+            var isNullable = Nullable.GetUnderlyingType(propertyInfo.PropertyType) != null;
+
+            var propType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+
+            if (propType.IsEnum)
+            {
+                if (isNullable)
+                {
+                    return new NullableEnumGenerator(Enum.GetValues(propType), allowNulls);
+                }
+
+                return new EnumGenerator(Enum.GetValues(propType));
+            }
+
+            return new Generator(propertyInfo);
         }
 
         public string PropertyName { get; private set; }
         public PropertyInfo PropertyInfo { get; private set; }
-        public IGenerator Generator { get; private set; }
+        public IGenerator<object> Generator { get; private set; }
 
         public object Generate()
         {

--- a/SampleWebApplication/Customer.cs
+++ b/SampleWebApplication/Customer.cs
@@ -64,10 +64,10 @@ namespace SampleWebApplication
             }
         }
 
-        private Company _company;
+        //private Company _company;
         public Company Company { get; set; }
 
-        private IList<Company> _companies;
+        //private IList<Company> _companies;
         public IList<Company> Companies {get;set;}
 
         


### PR DESCRIPTION
I found that "ObjectHydrator" is not supporting Nullable types. Therefore, I had added the support and also fixed some code warnings and code style issues.
Also found a bug related to Enum generator. Hydrator was always selecting first Enum value instead of selecting the random Enum value. Have fixed it with added support for Nullable Enum type.

@PrintsCharming : Could you please review it and merge to have updated nuget package if it is fine with you?